### PR TITLE
M2L4. Добавление тестов для TaskViewController

### DIFF
--- a/ToDoListCleanSwift.xcodeproj/project.pbxproj
+++ b/ToDoListCleanSwift.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		856D625629CDCA8300A0A1BB /* TasksViewControllerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856D625529CDCA8300A0A1BB /* TasksViewControllerSpy.swift */; };
 		856D625829CDD1B600A0A1BB /* TasksPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856D625729CDD1B600A0A1BB /* TasksPresenterTests.swift */; };
 		857021D629D2FF8B0096AA84 /* SectionAdapterSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857021D529D2FF8B0096AA84 /* SectionAdapterSpy.swift */; };
+		8570221029D5C4D40096AA84 /* TasksInteractorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8570220F29D5C4D40096AA84 /* TasksInteractorSpy.swift */; };
+		8570221229D5C4E50096AA84 /* TasksViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8570221129D5C4E50096AA84 /* TasksViewControllerTests.swift */; };
 		85E0C13029C4463100E8A29B /* ToDoListBusinessLogic in Frameworks */ = {isa = PBXBuildFile; productRef = 85E0C12F29C4463100E8A29B /* ToDoListBusinessLogic */; };
 /* End PBXBuildFile section */
 
@@ -107,6 +109,8 @@
 		856D625529CDCA8300A0A1BB /* TasksViewControllerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksViewControllerSpy.swift; sourceTree = "<group>"; };
 		856D625729CDD1B600A0A1BB /* TasksPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksPresenterTests.swift; sourceTree = "<group>"; };
 		857021D529D2FF8B0096AA84 /* SectionAdapterSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionAdapterSpy.swift; sourceTree = "<group>"; };
+		8570220F29D5C4D40096AA84 /* TasksInteractorSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksInteractorSpy.swift; sourceTree = "<group>"; };
+		8570221129D5C4E50096AA84 /* TasksViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksViewControllerTests.swift; sourceTree = "<group>"; };
 		85E0C12D29C445E300E8A29B /* ToDoListBusinessLogic */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ToDoListBusinessLogic; sourceTree = "<group>"; };
 		85E0C13129C44B0200E8A29B /* ToDoListCleanSwift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToDoListCleanSwift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -193,6 +197,7 @@
 				5E7E0F5229C58E3400BD13F4 /* TaskManagerSpy.swift */,
 				856D624929CCDB3C00A0A1BB /* TesksWorkerSpy.swift */,
 				856D624B29CCDB7000A0A1BB /* TasksPresenerSpy.swift */,
+				8570220F29D5C4D40096AA84 /* TasksInteractorSpy.swift */,
 				856D625529CDCA8300A0A1BB /* TasksViewControllerSpy.swift */,
 				857021D529D2FF8B0096AA84 /* SectionAdapterSpy.swift */,
 			);
@@ -290,6 +295,7 @@
 				5EF3941629D5BAC4003EAD88 /* TasksWorkerTests.swift */,
 				856D624729CCD6C000A0A1BB /* TasksInteractorTests.swift */,
 				856D625729CDD1B600A0A1BB /* TasksPresenterTests.swift */,
+				8570221129D5C4E50096AA84 /* TasksViewControllerTests.swift */,
 				5E40155029C974D0001F2DBB /* Managers */,
 			);
 			path = TasksScene;
@@ -466,6 +472,8 @@
 				856D624D29CCE95700A0A1BB /* TasksInteractorTests.swift in Sources */,
 				5EF3941729D5BAC4003EAD88 /* TasksWorkerTests.swift in Sources */,
 				856D625629CDCA8300A0A1BB /* TasksViewControllerSpy.swift in Sources */,
+				8570221229D5C4E50096AA84 /* TasksViewControllerTests.swift in Sources */,
+				8570221029D5C4D40096AA84 /* TasksInteractorSpy.swift in Sources */,
 				857021D629D2FF8B0096AA84 /* SectionAdapterSpy.swift in Sources */,
 				856D625829CDD1B600A0A1BB /* TasksPresenterTests.swift in Sources */,
 				5E7E0F5529C58E6800BD13F4 /* SectionAdapterTests.swift in Sources */,

--- a/ToDoListCleanSwiftTests/TestDoubles/TasksInteractorSpy.swift
+++ b/ToDoListCleanSwiftTests/TestDoubles/TasksInteractorSpy.swift
@@ -1,0 +1,32 @@
+//
+//  TasksInteractorSpy.swift
+//  ToDoListCleanSwiftTests
+//
+//  Created by Evgeni Meleshin on 24.03.2023.
+//
+
+@testable import ToDoListCleanSwift
+import Foundation
+
+final class TasksInteractorSpy: ITasksInteractor {
+
+	var invokedDidCheckboxTapped = false
+	var invokedDidCheckboxTappedCount = 0
+	var invokedDidCheckboxTappedParameters: (indexPath: IndexPath, Void)?
+	var invokedDidCheckboxTappedParametersList = [(indexPath: IndexPath, Void)]()
+
+	func didCheckboxTapped(indexPath: IndexPath) {
+		invokedDidCheckboxTapped = true
+		invokedDidCheckboxTappedCount += 1
+		invokedDidCheckboxTappedParameters = (indexPath, ())
+		invokedDidCheckboxTappedParametersList.append((indexPath, ()))
+	}
+
+	var invokedFetchData = false
+	var invokedFetchDataCount = 0
+
+	func fetchData() {
+		invokedFetchData = true
+		invokedFetchDataCount += 1
+	}
+}

--- a/ToDoListCleanSwiftTests/UnitTests/TasksScene/TasksViewControllerTests.swift
+++ b/ToDoListCleanSwiftTests/UnitTests/TasksScene/TasksViewControllerTests.swift
@@ -13,17 +13,15 @@ final class TasksViewControllerTests: XCTestCase {
 
 	// MARK: - Private properties
 
-	private var sut: TasksViewController! // swiftlint:disable:this implicitly_unwrapped_optional
 	private var interactor: TasksInteractorSpy! // swiftlint:disable:this implicitly_unwrapped_optional
-	private var worker: TasksWorkerSpy! // swiftlint:disable:this implicitly_unwrapped_optional
-	private var presenter: TasksPresenterSpy! // swiftlint:disable:this implicitly_unwrapped_optional
-	private var taskManagerSpy: TaskManagerSpy! // swiftlint:disable:this implicitly_unwrapped_optional
 
 	// MARK: - Tests
 
 	func test_viewDidLoad_shouldBeLoadSuccess() {
 		// arrange
-		let sut = makeSut()
+		let sut = TasksViewController()
+		interactor = TasksInteractorSpy()
+		sut.interactor = interactor
 
 		// act
 		sut.viewDidLoad()
@@ -34,7 +32,9 @@ final class TasksViewControllerTests: XCTestCase {
 
 	func test_render_shouldBeReceiveValidData() {
 		// arrange
-		let sut = makeSut()
+		let sut = TasksViewController()
+		interactor = TasksInteractorSpy()
+		sut.interactor = interactor
 		let viewData = expectedViewData()
 
 		// act
@@ -46,19 +46,6 @@ final class TasksViewControllerTests: XCTestCase {
 			viewData,
 			"Переданная в метод taskViewController.render вью модель отличается от ожидаемой"
 		)
-	}
-}
-
-// MARK: - Private
-
-private extension TasksViewControllerTests {
-	func makeSut() -> TasksViewController {
-		sut = TasksViewController()
-		interactor = TasksInteractorSpy()
-		worker = TasksWorkerSpy()
-		presenter = TasksPresenterSpy()
-		sut.interactor = interactor
-		return sut
 	}
 }
 

--- a/ToDoListCleanSwiftTests/UnitTests/TasksScene/TasksViewControllerTests.swift
+++ b/ToDoListCleanSwiftTests/UnitTests/TasksScene/TasksViewControllerTests.swift
@@ -1,0 +1,74 @@
+//
+//  TasksViewControllerTests.swift
+//  ToDoListCleanSwiftTests
+//
+//  Created by Evgeni Meleshin on 24.03.2023.
+//
+
+import XCTest
+import ToDoListBusinessLogic
+@testable import ToDoListCleanSwift
+
+final class TasksViewControllerTests: XCTestCase {
+
+	// MARK: - Private properties
+
+	private var sut: TasksViewController! // swiftlint:disable:this implicitly_unwrapped_optional
+	private var interactor: TasksInteractorSpy! // swiftlint:disable:this implicitly_unwrapped_optional
+	private var worker: TasksWorkerSpy! // swiftlint:disable:this implicitly_unwrapped_optional
+	private var presenter: TasksPresenterSpy! // swiftlint:disable:this implicitly_unwrapped_optional
+	private var taskManagerSpy: TaskManagerSpy! // swiftlint:disable:this implicitly_unwrapped_optional
+
+	// MARK: - Tests
+
+	func test_viewDidLoad_shouldBeLoadSuccess() {
+		// arrange
+		let sut = makeSut()
+
+		// act
+		sut.viewDidLoad()
+
+		// assert
+		XCTAssertTrue(interactor.invokedFetchData, "Не был вызван interactor.fetchData")
+	}
+
+	func test_render_shouldBeReceiveValidData() {
+		// arrange
+		let sut = makeSut()
+		let viewData = expectedViewData()
+
+		// act
+		sut.render(viewData: viewData)
+
+		// assert
+		XCTAssertEqual(
+			sut.viewData,
+			viewData,
+			"Переданная в метод taskViewController.render вью модель отличается от ожидаемой"
+		)
+	}
+}
+
+// MARK: - Private
+
+private extension TasksViewControllerTests {
+	func makeSut() -> TasksViewController {
+		sut = TasksViewController()
+		interactor = TasksInteractorSpy()
+		worker = TasksWorkerSpy()
+		presenter = TasksPresenterSpy()
+		sut.interactor = interactor
+		return sut
+	}
+}
+
+// MARK: - TestData
+
+private extension TasksViewControllerTests {
+	func expectedViewData() -> TaskModel.ViewData {
+		let regularTask = TaskModel.ViewData.RegularTask(title: "Regular task", checkboxImageName: "")
+		let tasks = TaskModel.ViewData.Task.regularTask(regularTask)
+		let section = TaskModel.ViewData.Section(title: "Невыполненные задачи", tasks: [tasks])
+		return TaskModel.ViewData(tasksBySections: [section])
+	}
+}


### PR DESCRIPTION
# Что было сделано?

- Добавлены тесты для TaskViewController.
- Добавлены необходимые двойники для реализации тестов.
- Скорректированы тексты в соответствии с кодстайлом.